### PR TITLE
Specified python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script was originally based off of an inspired by [this script](https://git
 **DISCLAIMER** although I'm a software developer, I have done very little python (this is my first real program). So please forgive the crudeness of some of my code or methods. PRs welcome!
 
 ## Installation
-Simply use pip to install the requirements and run the software with python.
+Simply use pip to install the requirements and run the software with python 3.
 
 ```python
 pip install -r requirements.txt


### PR DESCRIPTION
The application does not run in python 2 and so python version should be specified in README. The following error is thrown when trying to run it in python 2.

> Plex Username: {censored}
Traceback (most recent call last):
  File "main.py", line 66, in <module>
    plex = Plex()
  File "main.py", line 10, in __init__
    self.account = self.get_account()
  File "<decorator-gen-2>", line 2, in get_account
  File "/usr/local/lib/python2.7/dist-packages/retry/api.py", line 74, in retry_decorator
    logger)
  File "/usr/local/lib/python2.7/dist-packages/retry/api.py", line 33, in __retry_internal
    return f()
  File "main.py", line 17, in get_account
    username = input("Plex Username: ")
  File "<string>", line 1, in <module>
NameError: name {censored} is not defined
