### PR TITLE
fix YAMLLoadWarning

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def process_movies(movies, medium, collection):
             movie.addCollection(collection)
 
 with (open("collections.yml", "r")) as stream:
-    collections = yaml.load(stream)
+    collections = yaml.load(stream, Loader=yaml.SafeLoader)
 
 if __name__ == "__main__":
     plex = Plex()


### PR DESCRIPTION
The plain 'yaml.load(input)' function is deprecated in PyYAML 5.1 (see
https://msg.pyyaml.org/load). This pull request changes the
yaml.load command to 'yaml.load(stream, Loader=yaml.SafeLoader)' which
is recommended for loading untrusted input.